### PR TITLE
Rights API: OFFSET and LIMIT Queries (part deux: talking to a real da…

### DIFF
--- a/lib/rights_api/models/access_profile.rb
+++ b/lib/rights_api/models/access_profile.rb
@@ -3,6 +3,7 @@
 module RightsAPI
   class AccessProfile < Sequel::Model
     extend ModelExtensions
+    set_primary_key :id
 
     def to_h
       {

--- a/lib/rights_api/models/access_statement.rb
+++ b/lib/rights_api/models/access_statement.rb
@@ -3,6 +3,7 @@
 module RightsAPI
   class AccessStatement < Sequel::Model(:access_stmts)
     extend ModelExtensions
+    set_primary_key :stmt_key
 
     def self.default_key
       :stmt_key

--- a/lib/rights_api/models/access_statement_map.rb
+++ b/lib/rights_api/models/access_statement_map.rb
@@ -3,6 +3,7 @@
 module RightsAPI
   class AccessStatementMap < Sequel::Model(:access_stmts_map)
     extend ModelExtensions
+    set_primary_key [:a_attr, :a_access_profile]
 
     def self.default_key
       :attr_access_id

--- a/lib/rights_api/models/attribute.rb
+++ b/lib/rights_api/models/attribute.rb
@@ -3,6 +3,7 @@
 module RightsAPI
   class Attribute < Sequel::Model
     extend ModelExtensions
+    set_primary_key :id
 
     def to_h
       {

--- a/lib/rights_api/models/reason.rb
+++ b/lib/rights_api/models/reason.rb
@@ -3,6 +3,7 @@
 module RightsAPI
   class Reason < Sequel::Model
     extend ModelExtensions
+    set_primary_key :id
 
     def to_h
       {

--- a/lib/rights_api/models/rights_current.rb
+++ b/lib/rights_api/models/rights_current.rb
@@ -10,6 +10,7 @@ module RightsAPI
     many_to_one :attribute_obj, class: :"RightsAPI::Attribute", key: :attr
     many_to_one :reason_obj, class: :"RightsAPI::Reason", key: :reason
     many_to_one :source_obj, class: :"RightsAPI::Source", key: :source
+    set_primary_key [:namespace, :id]
 
     # Maybe TOO eager. This makes us partially responsible for the fact that rights_current.source
     # has an embedded access_profile.

--- a/lib/rights_api/models/rights_log.rb
+++ b/lib/rights_api/models/rights_log.rb
@@ -10,6 +10,7 @@ module RightsAPI
     many_to_one :attribute_obj, class: :"RightsAPI::Attribute", key: :attr
     many_to_one :reason_obj, class: :"RightsAPI::Reason", key: :reason
     many_to_one :source_obj, class: :"RightsAPI::Source", key: :source
+    set_primary_key [:namespace, :id]
 
     # Maybe TOO eager. This makes us partially responsible for the fact that rights_current.source
     # has an embedded access_profile.


### PR DESCRIPTION
…tabase)

- Make explicit the primary key in each model.
  - Sequel needs this for classes with associations.
  - Sequel appears to have a rough time getting this info from a view vs a table.