### PR TITLE
ETT-420 Update Database Credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,10 @@ services:
       - gem_cache:/gems
     command: bundle exec puma -p 4567 config.ru
     environment:
-      RIGHTS_API_DATABASE_CONNECTION_STRING: "mysql2://ht_rights:ht_rights@mariadb/ht"
+      MARIADB_HT_RO_USERNAME: ht_rights
+      MARIADB_HT_RO_PASSWORD: ht_rights
+      MARIADB_HT_RO_HOST: mariadb
+      MARIADB_HT_RO_DATABASE: ht
       RIGHTS_API_LOGGER_LEVEL: 1 # Logger::INFO
     depends_on:
       mariadb: *healthy

--- a/lib/rights_api/database.rb
+++ b/lib/rights_api/database.rb
@@ -4,43 +4,19 @@ require "sequel"
 
 module RightsAPI
   class Database
-    # .connect will take
-    #  * a full connection string (passed here OR in the environment
-    #    variable RIGHTS_API_DATABASE_CONNECTION_STRING)
-    #  * a set of named arguments, drawn from those passed in and the
-    #    environment. Arguments are those supported by Sequel.
-    #
-    # Environment variables are mapped as follows:
-    #
-    #   user: RIGHTS_API_DATABASE_USER
-    #   password: RIGHTS_API_DATABASE_PASSWORD
-    #   host: RIGHTS_API_DATABASE_HOST
-    #   port: RIGHTS_API_DATABASE_PORT
-    #   database: RIGHTS_API_DATABASE_DATABASE
-    #   adapter: RIGHTS_API_DATABASE_ADAPTER
-    def connect(connection_string = nil, **)
-      return @connection if @connection
+    attr_reader :connection
 
-      connection_string ||= ENV["RIGHTS_API_DATABASE_CONNECTION_STRING"]
-      if connection_string.nil?
-        db_args = gather_args(**)
-        Sequel.connect(**db_args)
-      else
-        Sequel.connect(connection_string)
-      end
-    end
-
-    private
-
-    def gather_args(**args)
-      %i[user password host port database adapter].each do |arg|
-        args[arg] ||= ENV["RIGHTS_API_DATABASE_#{arg.to_s.upcase}"]
-      end
-
-      args[:host] ||= "localhost"
-      args[:adapter] ||= :mysql2
-      args[:database] ||= "ht"
-      args
+    def initialize
+      @connection = Sequel.connect(
+        adapter: :mysql2,
+        user: ENV["MARIADB_HT_RO_USERNAME"],
+        password: ENV["MARIADB_HT_RO_PASSWORD"],
+        host: ENV["MARIADB_HT_RO_HOST"],
+        database: ENV["MARIADB_HT_RO_DATABASE"],
+        encoding: "utf8mb4"
+      )
+      @connection.extension(:connection_validator)
+      @connection.pool.connection_validation_timeout = 5
     end
   end
 end

--- a/lib/rights_api/services.rb
+++ b/lib/rights_api/services.rb
@@ -16,7 +16,7 @@ module RightsAPI
   end
 
   Services.register(:database_connection) do
-    Services[:database].connect.tap do |connection|
+    Services[:database].connection.tap do |connection|
       connection.logger = Services[:logger]
     end
   end

--- a/spec/unit/database_spec.rb
+++ b/spec/unit/database_spec.rb
@@ -10,38 +10,15 @@ RSpec.describe RightsAPI::Database do
   end
 
   describe "#connect" do
-    it "connects with built-in connection string" do
-      expect(described_class.new).not_to be nil
-    end
-
-    it "connects with explicit connection string" do
-      expect(described_class.new.connect(ENV["RIGHTS_API_DATABASE_CONNECTION_STRING"])).not_to be nil
-    end
-
-    it "connects with connection arguments" do
-      ClimateControl.modify(RIGHTS_API_DATABASE_CONNECTION_STRING: nil) do
-        args = {
-          user: "ht_rights",
-          password: "ht_rights",
-          host: "mariadb",
-          database: "ht",
-          adapter: "mysql2"
-        }
-        expect(described_class.new.connect(**args)).not_to be nil
-      end
-    end
-
     it "connects with ENV variables" do
       env = {
-        RIGHTS_API_DATABASE_CONNECTION_STRING: nil,
-        RIGHTS_API_DATABASE_USER: "ht_rights",
-        RIGHTS_API_DATABASE_PASSWORD: "ht_rights",
-        RIGHTS_API_DATABASE_HOST: "mariadb",
-        RIGHTS_API_DATABASE_DATABASE: "ht",
-        RIGHTS_API_DATABASE_ADAPTER: "mysql2"
+        MARIADB_HT_RO_USERNAME: "mdp-admin",
+        MARIADB_HT_RO_PASSWORD: "mdp-admin",
+        MARIADB_HT_RO_HOST: "mariadb",
+        MARIADB_HT_RO_DATABASE: "ht"
       }
       ClimateControl.modify(**env) do
-        expect(described_class.new.connect).not_to be nil
+        expect(described_class.new.connection).not_to be nil
       end
     end
   end


### PR DESCRIPTION
- Switch to standard `MARIADB_*` ENV to replace obsolete `DATA_API_*`… keys.
- Do away with connection string and simplify `Database` class in imitation of holdings-backend and others.
- Use `connection_validator` extension with Sequel connection to allow reconnects. (ETT-430)